### PR TITLE
Fix renamed Spacemacs function get-package-directory

### DIFF
--- a/ponylang/packages.el
+++ b/ponylang/packages.el
@@ -36,7 +36,7 @@
     (use-package flycheck-pony))
 
 (defun ponylang/init-pony-snippets ()
-  (setq pony-snippets-dir (spacemacs//get-package-directory 'pony-snippets))
+  (setq pony-snippets-dir (configuration-layer//get-package-directory 'pony-snippets))
 
   (defun pony-snippets-initialize ()
     (let ((snip-dir (expand-file-name "snippets" pony-snippets-dir)))


### PR DESCRIPTION
At some point this function was renamed. Without this fix, the layer gives this error while loading:

```
Symbol's function definition is void: "spacemacs//get-package-directory"
```